### PR TITLE
docs: add terminal process management documentation

### DIFF
--- a/doc/hotkeys/process-management.md
+++ b/doc/hotkeys/process-management.md
@@ -1,0 +1,31 @@
+## Commandes liées à la gestion de processus
+
+La gestion des processus en ligne de commande permet de contrôler et surveiller les programmes en cours d'exécution sur un système d'exploitation.
+
+
+### Affichage des processus
+
+Pour **voir** la liste des processus en cours, on utilise généralement la commande : `ps`
+
+Cette commande affiche les informations **essentielles** comme **l'identifiant** du processus (PID), le terminal associé, le **temps d'exécution** et le **nom** de la commande.
+
+
+---
+
+
+### D'autres commandes :
+
+#### top 
+
+`top` est l'outil de base pour **surveiller** les processus **en temps réel**.
+Il affiche une vue **dynamique** des processus en cours d'exécution, et **trie** par défaut les processus selon l'utilisation CPU.
+Cela permet une **mise à jour périodique** des informations.  
+<br>
+
+#### htop
+
+`htop` est une version **améliorée** de `top` avec une interface plus conviviale.
+Il possède :
+- un affichage en **couleur** et plus **intuitif**
+- une navigation **verticale** et **horizontale** dans la liste des processus
+- une utilisation **possible** de la souris


### PR DESCRIPTION
### Summary 
_Documentation of the process management on a terminal_
### Details
_This documentation talks about the process management on a Linux Terminal.
You can find here the `ps`, `top`and `htop` commands._

### References 
No reference.
### CHECKS 

- [x] Tested changes

### DISCLAIMER
_This is a v1 of the document. This might be evolving._

